### PR TITLE
add methods to interpret some logical types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "626c502c-15b0-58ad-a749-f091afb673ae"
 keywords = ["parquet", "julia", "columnar-storage"]
 license = "MIT"
 desc = "Julia implementation of parquet columnar file format reader"
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
@@ -11,6 +11,7 @@ MemPool = "f9f48841-c794-520a-933b-121f7ba6ed94"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Snappy = "59d4ed8c-697a-5b28-a4c7-fe95c22820f9"
 Thrift = "8d9c9c80-f77e-5080-9541-c6f69d204e22"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
 CodecZlib = "0.5,0.6,0.7"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Load a [parquet file](https://en.wikipedia.org/wiki/Apache_Parquet). Only metadata is read initially, data is loaded in chunks on demand. (Note: [ParquetFiles.jl](https://github.com/queryverse/ParquetFiles.jl) also provides load support for Parquet files under the FileIO.jl package.)
 
-````julia
+```julia
 julia> using Parquet
 
 julia> parfile = "customer.impala.parquet"
@@ -16,11 +16,11 @@ Parquet file: /home/tan/Work/julia/packages/Parquet/test/parquet-compatibility/p
     nrows: 150000
     created by: impala version 1.2-INTERNAL (build a462ec42e550c75fccbff98c720f37f3ee9d55a3)
     cached: 0 column chunks
-````
+```
 
 Examine the schema.
 
-````julia
+```julia
 julia> nrows(p)
 150000
 
@@ -50,11 +50,11 @@ Schema:
       optional BYTE_ARRAY c_mktsegment
       optional BYTE_ARRAY c_comment
     }
-````
+```
 
 Can convert the parquet schema to different forms:
 
-````julia
+```julia
 julia> schema(JuliaConverter(stdout), p, :Customer)
 type Customer
     Customer() = new()
@@ -91,19 +91,19 @@ message Customer {
     optional bytes c_mktsegment;
     optional bytes c_comment;
 }
-````
+```
 
 Can inject the type dynamically to a module to have further methods working directly on the Julia type.
 
-````julia
+```julia
 julia> schema(JuliaConverter(Main), p, :Customer)
 
 julia> Base.show(io::IO, cust::Customer) = println(io, String(copy(cust.c_name)), " Phone#:", String(copy(cust.c_phone)))
-````
+```
 
 Create cursor to iterate over records. In parallel mode, multiple remote cursors can be created and iterated on in parallel.
 
-````julia
+```julia
 julia> rc = RecCursor(p, 1:5, colnames(p), JuliaBuilder(p, Customer))
 Record Cursor on /home/tan/Work/julia/packages/Parquet/test/parquet-compatibility/parquet-testdata/impala/1.1.1-SNAPPY/customer.impala.parquet
     rows: 1:5
@@ -122,5 +122,18 @@ Customer#000000001 Phone#:25-989-741-2988
 Customer#000000642 Phone#:32-925-597-9911
 Customer#000000161 Phone#:17-805-718-2449
 
-````
+```
+
+The reader does not interpret any logical types by default. For example, timestamps that are `INT96` values will be represented by default as Julia Int128 types. There will be additional methods provided to interpret such fields which can be applied on the values after they are read. As of now methods are available for:
+
+- timestamp: `logical_timestamp`
+- string: `logical_string`
+
+```
+julia> for v in values
+        println(logical_string(v.date_string_col), ", ", logical_timestamp(v.timestamp_col))
+       end
+04/01/09, 2009-04-01T12:00:00
+04/01/09, 2009-04-01T12:01:00
+```
 

--- a/src/Parquet.jl
+++ b/src/Parquet.jl
@@ -5,12 +5,14 @@ using ProtoBuf
 using Snappy
 using CodecZlib
 using MemPool
+using Dates
 
 import Base: show, open, close, values
 import Thrift: isfilled
 
 export is_par_file, ParFile, show, nrows, ncols, rowgroups, columns, pages, bytes, values, colname, colnames
 export SchemaConverter, schema, JuliaConverter, ThriftConverter, ProtoConverter
+export logical_timestamp, logical_string
 export RowCursor, ColCursor, RecCursor
 export AbstractBuilder, JuliaBuilder
 

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -258,16 +258,16 @@ function read_bitpacked_run_old(io::IO, count::Integer, bits::Integer, byt::Int=
     arr
 end
 
-function logical_timestamp(barr)
+function logical_timestamp(barr; offset::Dates.Period=Dates.Second(0))
     nanos = read(IOBuffer(barr[1:8]), Int64)
     julian_days = read(IOBuffer(barr[9:12]), Int32)
-    Dates.julian2datetime(julian_days) + Dates.Nanosecond(nanos)
+    Dates.julian2datetime(julian_days) + Dates.Nanosecond(nanos) + offset
 end
 
-function logical_timestamp(i128::Int128)
+function logical_timestamp(i128::Int128; offset::Dates.Period=Dates.Second(0))
     iob = IOBuffer()
     write(iob, i128)
-    logical_timestamp(take!(iob))
+    logical_timestamp(take!(iob); offset=offset)
 end
 
 logical_string(bytes::Vector{UInt8}) = String(copy(bytes))

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -257,3 +257,17 @@ function read_bitpacked_run_old(io::IO, count::Integer, bits::Integer, byt::Int=
     end
     arr
 end
+
+function logical_timestamp(barr)
+    nanos = read(IOBuffer(barr[1:8]), Int64)
+    julian_days = read(IOBuffer(barr[9:12]), Int32)
+    Dates.julian2datetime(julian_days) + Dates.Nanosecond(nanos)
+end
+
+function logical_timestamp(i128::Int128)
+    iob = IOBuffer()
+    write(iob, i128)
+    logical_timestamp(take!(iob))
+end
+
+logical_string(bytes::Vector{UInt8}) = String(copy(bytes))

--- a/test/test_load.jl
+++ b/test/test_load.jl
@@ -1,5 +1,6 @@
 using Parquet
 using Test
+using Dates
 
 function test_load(file, parcompat=joinpath(dirname(@__FILE__), "parquet-compatibility"))
     p = ParFile(joinpath(parcompat, file))
@@ -84,7 +85,8 @@ function test_load_all_pages()
     end
 end
 
-function test_load_boolean()
+function test_load_boolean_and_ts()
+    println("testing booleans and timestamps...")
     p = ParFile("booltest/alltypes_plain.snappy.parquet")
     schema(JuliaConverter(Main), p, :AllTypes)
     rg = rowgroups(p)
@@ -104,9 +106,11 @@ function test_load_boolean()
     end
 
     @test [v.bool_col for v in values] == [true,false]
+    @test [logical_timestamp(v.timestamp_col) for v in values] == [DateTime("2009-04-01T12:00:00"), DateTime("2009-04-01T12:01:00")]
+    @test [logical_string(v.date_string_col) for v in values] == ["04/01/09", "04/01/09"]
     #dlm,headers=readdlm("booltest/alltypes.csv", ','; header=true)
     #@test [v.bool_col for v in values] == dlm[:,2]  # skipping for now as this needs additional dependency on DelimitedFiles
 end
 
 test_load_all_pages()
-test_load_boolean()
+test_load_boolean_and_ts()

--- a/test/test_load.jl
+++ b/test/test_load.jl
@@ -107,6 +107,7 @@ function test_load_boolean_and_ts()
 
     @test [v.bool_col for v in values] == [true,false]
     @test [logical_timestamp(v.timestamp_col) for v in values] == [DateTime("2009-04-01T12:00:00"), DateTime("2009-04-01T12:01:00")]
+    @test [logical_timestamp(v.timestamp_col; offset=Dates.Second(30)) for v in values] == [DateTime("2009-04-01T12:00:30"), DateTime("2009-04-01T12:01:30")]
     @test [logical_string(v.date_string_col) for v in values] == ["04/01/09", "04/01/09"]
     #dlm,headers=readdlm("booltest/alltypes.csv", ','; header=true)
     #@test [v.bool_col for v in values] == dlm[:,2]  # skipping for now as this needs additional dependency on DelimitedFiles


### PR DESCRIPTION
The reader does not interpret any logical types. For example, timestamps that are `INT96` values will be represented by default as Julia Int128 types (the next higher type available). Logical type information is also often not present in schema.

We could provide additional methods to interpret such fields. They can be applied on the values after they are read.

As of now this PR adds methods for timestamp (`logical_timestamp`) and strings (`logical_string`):

```julia
julia> for v in values
        println(logical_string(v.date_string_col), ", ", logical_timestamp(v.timestamp_col))
       end
04/01/09, 2009-04-01T12:00:00
04/01/09, 2009-04-01T12:01:00
```

fixes #49 