### PR TITLE
Fix fieldnames

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -256,7 +256,7 @@ function _sch_to_julia(sch::SchemaElement, ios::Vector{IO}, nchildren::Vector{In
         jtypestr = string(jtype)
     else
         # this is a composite type
-        jtypestr = sch.name * "Type"
+        jtypestr = "var\"" * replace(sch.name, "\""=>"\\\"") * "Type\""
     end
     # we are not looking at converted types yet
 
@@ -266,7 +266,7 @@ function _sch_to_julia(sch::SchemaElement, ios::Vector{IO}, nchildren::Vector{In
     end
 
     if lchildren > 0
-        println(ios[end], "    ", sch.name, "::", jtypestr)
+        println(ios[end], "    var\"", replace(sch.name, "\""=>"\\\""), "\"::", jtypestr)
     end
 
     if isfilled(sch, :num_children)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -272,7 +272,7 @@ function _sch_to_julia(sch::SchemaElement, ios::Vector{IO}, nchildren::Vector{In
     if isfilled(sch, :num_children)
         if lchildren > 0
             lvlio = IOBuffer()
-            println(lvlio, "type ", jtypestr)
+            println(lvlio, "mutable struct ", jtypestr)
             println(lvlio, "    ", jtypestr, "() = new()")
             push!(ios, lvlio)
         end


### PR DESCRIPTION
Fixes https://github.com/queryverse/ParquetFiles.jl/issues/23.
Fixes https://github.com/queryverse/ParquetFiles.jl/issues/22.
Fixes https://github.com/queryverse/ParquetFiles.jl/issues/19 (not yet).

I've got pretty far, but this is not enough. Right now I'm stuck [here](https://github.com/JuliaIO/Parquet.jl/blob/d910f57825db3edd7919e737bc1f21fe86e4e847/src/schema.jl#L72): `parentname` here assumes that a field name doesn't use a dot `.` in its name, and I'm not sure how to fix that.

@tanmaykm is there a chance that you could take this PR from here and finish support for arbitrary column names?

In general I'm wondering whether this design of creating custom types is still necessary? I completely understand that it was the right call pre Julia 1.0, but now one could probably just use named tuples for all of this and reduce the complexity of the code a lot? I wouldn't be able to make that change, though...