### PR TITLE
update Thrift dependency, drop ProtoBuf dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,13 @@ uuid = "626c502c-15b0-58ad-a749-f091afb673ae"
 keywords = ["parquet", "julia", "columnar-storage"]
 license = "MIT"
 desc = "Julia implementation of parquet columnar file format reader"
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 MemPool = "f9f48841-c794-520a-933b-121f7ba6ed94"
-ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Snappy = "59d4ed8c-697a-5b28-a4c7-fe95c22820f9"
 Thrift = "8d9c9c80-f77e-5080-9541-c6f69d204e22"
 
@@ -18,9 +17,8 @@ Thrift = "8d9c9c80-f77e-5080-9541-c6f69d204e22"
 CodecZlib = "0.5,0.6,0.7"
 CodecZstd = "0.6,0.7"
 MemPool = "0.2"
-ProtoBuf = "0.7,0.8"
 Snappy = "0.3"
-Thrift = "0.6"
+Thrift = "0.6,0.7"
 julia = "1"
 
 [extras]

--- a/src/Parquet.jl
+++ b/src/Parquet.jl
@@ -1,7 +1,6 @@
 module Parquet
 
 using Thrift
-using ProtoBuf
 using Snappy
 using CodecZlib
 using CodecZstd

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -370,7 +370,7 @@ function metadata_length(io)
     seek(io, sz - SZ_PAR_MAGIC - SZ_FOOTER)
 
     # read footer size as little endian signed Int32
-    ProtoBuf.read_fixed(io, Int32)
+    read_fixed(io, Int32)
 end
 
 function metadata(io, path::AbstractString, len::Integer=metadata_length(io))


### PR DESCRIPTION
- Update Thrift dependency to include v0.7
- Dependency on ProtoBuf.jl was unnecessary as the method being used from there was already available in Parquet.jl. Dropped it.