### PR TITLE
performace improvements, few fixes

### DIFF
--- a/src/codec.jl
+++ b/src/codec.jl
@@ -77,48 +77,60 @@ end
 const PLAIN_JTYPES = (Bool, Int32, Int64, Int128, Float32, Float64,      UInt8,               UInt8)
 
 # read plain encoding (PLAIN = 0)
-function read_plain(io::IO, typ::Int32, jtype::Type{T}=PLAIN_JTYPES[typ+1]) where {T}
-    if typ === _Type.BYTE_ARRAY
-        count = read_fixed(io, Int32)
-        #@debug("reading bytearray length:$count")
-        read!(io, Array{UInt8}(undef, count))
-    elseif typ === _Type.BOOLEAN
-        error("not implemented") # reading single boolean values is not possible, vectors are read via read_bitpacked_booleans
+function read_plain_byte_array(io)
+    count = read_fixed(io, Int32)
+    read!(io, Array{UInt8}(undef, count))
+end
+
+function plain_values_eltype(typ::Int32)
+    if typ === _Type.BOOLEAN
+        Bool
+    elseif typ === _Type.BYTE_ARRAY
+        Vector{UInt8}
     elseif typ === _Type.FIXED_LEN_BYTE_ARRAY
-        #@debug("reading fixedlenbytearray length:$count")
-        #read!(io, Array{UInt8}(count))
         error("not implemented") # this is likely same as BYTE_ARRAY for decoding purpose
     else
-        #@debug("reading type:$jtype, typenum:$typ")
-        read_fixed(io, jtype)
+        PLAIN_JTYPES[typ+1]
     end
 end
 
 # read plain values or dictionary (PLAIN_DICTIONARY = 2)
-function read_plain_values(io::IO, count::Int32, typ::Int32)
+function read_plain_values(io, count::Int32, typ::Int32)
+    T = plain_values_eltype(typ)
+    arr = Array{T}(undef, count)
+    read_plain_values(io, count, typ, arr)
+end
+function read_plain_values(io, count::Int32, typ::Int32, arr::Vector{T}, offset::Int=0) where {T}
     #@debug("reading plain values", type=typ, count=count)
-    if typ == _Type.BOOLEAN
-        arr = read_bitpacked_booleans(io, count)
+    if typ === _Type.BOOLEAN
+        arr = read_bitpacked_booleans(io, count, arr)
+    elseif typ === _Type.BYTE_ARRAY
+        @inbounds for i in 1:count
+            arr[i+offset] = read_plain_byte_array(io)
+        end
+    elseif typ === _Type.FIXED_LEN_BYTE_ARRAY
+        error("not implemented") # this is likely same as BYTE_ARRAY for decoding purpose
     else
-        arr = [read_plain(io, typ) for i in 1:count]
+        @inbounds for i in 1:count
+            arr[i+offset] = read_fixed(io, T)
+        end
     end
     #@debug("read $(length(arr)) plain values")
     arr
 end
 
-function read_bitpacked_booleans(io::IO, count::Int32)::Vector{Bool}
+function read_bitpacked_booleans(io::IO, count::Int32, arr::Vector{Bool}, offset::Int=0)::Vector{Bool}
     #@debug("reading bitpacked booleans", count)
-    arr = fill!(Array{Bool}(undef, count), false)
     arrpos = 1
     bits = UInt8(0)
     bitpos = 9
-    while arrpos <= count
+    @inbounds while arrpos <= count
         if bitpos > 8
             bits = read(io, UInt8)
             #@debug("bits", bits, bitstring(bits))
             bitpos = 1
         end
-        arr[arrpos] = Bool(bits & 0x1)
+        arr[arrpos+offset] = Bool(bits & 0x1)
         arrpos += 1
         bits >>= 1
         bitpos += 1
@@ -127,65 +139,65 @@ function read_bitpacked_booleans(io::IO, count::Int32)::Vector{Bool}
 end
 
 # read rle dictionary (RLE_DICTIONARY = 8, or PLAIN_DICTIONARY = 2 in a data page)
-function read_rle_dict(io::IO, count::Int32)
+
+function read_rle_dict(io, count::Int32)
     bits = read(io, UInt8)
-    #@debug("reading rle dictionary bits:$bits")
-    arr = read_hybrid(io, count, Val{bits}(); read_len=false)
-    #@debug("read $(length(arr)) dictionary values")
-    arr
+    read_hybrid(io, count, Val{bits}(); read_len=false)
 end
 
 # read RLE or bit backed format (RLE = 3)
-function read_hybrid(io::IO, count::Int32, ::Val{W}; read_len::Bool=true) where {W}
+function read_hybrid(io, count::Int32, ::Val{W}; read_len::Bool=true) where {W}
     byte_width = @bit2bytewidth(W)
     typ = @byt2itype(byte_width)
     arr = Array{typ}(undef, count)
 
-    read_hybrid(io, count, W, byte_width, typ, arr; read_len=read_len)
+    read_hybrid(io, count, W, byte_width, arr, 0; read_len=read_len)
 end
-function read_hybrid(io::IO, count::Int32, bits::UInt8, byt::Int, typ::Type{T}, arr::Vector{T}; read_len::Bool=true) where {T <: Integer}
+function read_hybrid(io, count::Int32, bits::UInt8, arr::Vector{T}, offset::Int=0; read_len::Bool=true) where {T}
+    byte_width = @bit2bytewidth(bits)
+    read_hybrid(io, count, bits, byte_width, arr, offset; read_len=read_len)
+end
+function read_hybrid(io, count::Int32, bits::UInt8, byt::Int, arr::Vector{T}, offset::Int=0; read_len::Bool=true) where {T}
     len = read_len ? read_fixed(io, Int32) : Int32(0)
-    @debug("reading hybrid data", len, count, bits)
+    #@debug("reading hybrid data", len, count, bits)
     mask = MASKN(bits)
     arrpos = 1
+    offset -= 1    # to counter arrpos starting at 1
     while arrpos <= count
         runhdr = _read_varint(io, Int)
         isbitpack = ((runhdr & 0x1) == 0x1)
         runhdr >>= 1
-        nitems = isbitpack ? min(runhdr*8, count - arrpos + 1) : runhdr
-        #@debug("nitems=$nitems, isbitpack:$isbitpack, runhdr:$runhdr, remaininglen: $(count - arrpos + 1)")
-        #@debug("creating sub array for $nitems items at $arrpos, total length:$(length(arr))")
-        subarr = unsafe_wrap(Array, pointer(arr, arrpos), nitems, own=false)
+        nitems = min(isbitpack ? runhdr*8 : runhdr, count - arrpos + 1)
 
         if isbitpack
-            read_bitpacked_run(io, runhdr, bits, byt, typ, subarr, mask)
+            read_bitpacked_run(io, runhdr, bits, byt, arr, offset+arrpos, mask)
         else # rle
             read_type = @byt2uitype(byt)
-            read_rle_run(io, runhdr, bits, byt, typ, subarr, read_type)
+            read_rle_run(io, nitems, bits, byt, arr, read_type, offset+arrpos)
         end
         arrpos += nitems
     end
     arr
 end
 
-function read_rle_run(io::IO, count::Int, bits::UInt8, byt::Int, reinterpreted_typ::Type{T}, arr::Vector{T}, read_type::Type{V}) where {T <: Integer, V <: Integer}
+function read_rle_run(io, count::Int, bits::UInt8, byt::Int, arr::Vector{T}, read_type::Type{V}, offset::Int=0) where {T,V}
     #@debug("read_rle_run", count, T, bits, byt)
     val = reinterpret(T, _read_fixed(io, zero(V), byt))
-    @assert length(arr) >= count
+    @assert length(arr) >= (count+offset)
     @inbounds for idx in 1:count
-        arr[idx] = val
+        arr[idx+offset] = val
     end
     arr
 end
 
-function read_bitpacked_run(io::IO, grp_count::Int, ::Val{W}) where {W}
+function read_bitpacked_run(io, grp_count::Int, ::Val{W}) where {W}
     byte_width = @bit2bytewidth(W)
     typ = @byt2itype(byte_width)
     arr = Array{typ}(undef, grp_count)
-    read_bitpacked_run(io, grp_count, W, byte_width, typ, arr)
+    read_bitpacked_run(io, grp_count, W, byte_width, arr)
 end
-function read_bitpacked_run(io::IO, grp_count::Int, bits::UInt8, byt::Int, typ::Type{T}, arr::Vector{T}, mask::V=MASKN(bits)) where {T <: Integer, V <: Integer}
-    count = min(grp_count * 8, length(arr))
+function read_bitpacked_run(io, grp_count::Int, bits::UInt8, byt::Int, arr::Vector{T}, offset::Int=0, mask::V=MASKN(bits)) where {T,V}
+    count = min(grp_count * 8, length(arr)-offset)
     # multiple of 8 values at a time are bit packed together
     nbytes = bits * grp_count # same as: round(Int, (bits * grp_count * 8) / 8)
     #@debug("read_bitpacked_run. grp_count:$grp_count, count:$count, nbytes:$nbytes, nbits:$bits, available:$(bytesavailable(io))")
@@ -204,7 +216,7 @@ function read_bitpacked_run(io::IO, grp_count::Int, bits::UInt8, byt::Int, typ::
             # we have leftover bits, which must be appended
             if nbitsbuff < bits
                 # but only append if we need to read more in this cycle
-                @inbounds arr[arridx] = bitbuff & MASKN(nbitsbuff, V)
+                @inbounds arr[arridx+offset] = bitbuff & MASKN(nbitsbuff, V)
                 shift = nbitsbuff
                 nbitsbuff = UInt8(0)
                 bitbuff = zero(V)
@@ -224,13 +236,13 @@ function read_bitpacked_run(io::IO, grp_count::Int, bits::UInt8, byt::Int, typ::
             if shift > 0
                 remshift = bits - shift
                 #@debug("setting part from bitbuff nbitsbuff:$nbitsbuff, shift:$shift, remshift:$remshift")
-                arr[arridx] |= convert(T, (bitbuff << shift) & mask)
+                arr[arridx+offset] |= convert(T, (bitbuff << shift) & mask)
                 bitbuff >>= remshift
                 nbitsbuff -= remshift
                 shift = UInt8(0)
             else
                 #@debug("setting all from bitbuff nbitsbuff:$nbitsbuff")
-                arr[arridx] = convert(T, bitbuff & mask)
+                arr[arridx+offset] = convert(T, bitbuff & mask)
                 bitbuff >>= bits
                 nbitsbuff -= bits
             end
@@ -241,13 +253,13 @@ function read_bitpacked_run(io::IO, grp_count::Int, bits::UInt8, byt::Int, typ::
 end
 
 # read bit packed in deprecated format (BIT_PACKED = 4)
-function read_bitpacked_run_old(io::IO, count::Int32, ::Val{W}) where {W}
+function read_bitpacked_run_old(io, count::Int32, ::Val{W}) where {W}
     byte_width = @bit2bytewidth(W)
     typ = @byt2itype(byte_width)
     arr = Array{typ}(undef, count)
-    read_bitpacked_run_old(io, count, W, byte_width, typ, arr)
+    read_bitpacked_run_old(io, count, W, arr)
 end
-function read_bitpacked_run_old(io::IO, count::Int32, bits::UInt8, byt::Int, typ::Type{T}, arr::Vector{T}, mask::V=MASKN(bits)) where {T <: Integer, V <: Integer}
+function read_bitpacked_run_old(io, count::Int32, bits::UInt8, arr::Vector{T}, offset::Int32=Int32(0), mask::V=MASKN(bits)) where {T <: Integer, V <: Integer}
     # multiple of 8 values at a time are bit packed together
     nbytes = round(Int, (bits * count) / 8)
     #@debug("read_bitpacked_run. count:$count, nbytes:$nbytes, nbits:$bits")
@@ -278,14 +290,14 @@ function read_bitpacked_run_old(io::IO, count::Int32, bits::UInt8, byt::Int, typ
             dataidx += Int32(1)
             # shift bitbuff by diffnbits, add diffnbits and set result
             nbitsbuff = 8 - diffnbits
-            arr[arridx] = convert(T, ((bitbuff << diffnbits) | (nxtdata >> nbitsbuff)) & mask)
+            arr[arridx+offset] = convert(T, ((bitbuff << diffnbits) | (nxtdata >> nbitsbuff)) & mask)
             arridx += Int32(1)
             # keep remaining bits in bitbuff
             bitbuff <<= 8
             bitbuff |= nxtdata
         else
             # set result
-            arr[arridx] = convert(T, (bitbuff >> abs(diffnbits)) & mask)
+            arr[arridx+offset] = convert(T, (bitbuff >> abs(diffnbits)) & mask)
             arridx += Int32(1)
             nbitsbuff -= bits
         end

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -137,7 +137,10 @@ function setrow(cursor::ColCursor{T}, row::Int64) where {T}
             if isempty(repn_levels)
                 nrowscc = length(vals) # number of values is number of rows
             else
-                nrowscc = length(repn_levels) - length(find(repn_levels))   # number of values where repetition level is 0
+                nrowscc = 0
+                for i in 1:length(repn_levels)
+                    (repn_levels[i] !== Int32(0)) && (nrowscc += 1)
+                end
             end
             ccrange = startrow:(startrow + nrowscc)
 
@@ -175,7 +178,8 @@ function setrow(cursor::ColCursor{T}, row::Int64) where {T}
         else
             # multiple entries may constitute one row
             idx = first(ccrange)
-            levelpos = findfirst(repn_levels, 0) # NOTE: can start from cursor.levelpos to optimize, but that will prevent using setrow to go backwards
+            levelpos = findfirst(x->x===Int32(0), repn_levels) # NOTE: can start from cursor.levelpos to optimize, but that will prevent using setrow to go backwards
+            @assert levelpos !== nothing
             while idx < row
                 levelpos = findnext(repn_levels, 0, levelpos+1)
                 idx += 1

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -218,6 +218,14 @@ function values(par::ParFile, col::ColumnChunk)
             enc, defn_enc, rep_enc = page_encodings(pg)
             if enc == Encoding.PLAIN_DICTIONARY || enc == Encoding.RLE_DICTIONARY
                 append!(vals, map_dict_vals(valdict, _vals))
+                #=
+                if isempty(valdict)
+                    append!(vals, _vals)
+                else
+                    mapped_vals = [valdict[v+1] for v in _vals]
+                    append!(vals, mapped_vals)
+                end
+                =#
             else
                 append!(vals, _vals)
             end

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -130,13 +130,13 @@ function rowgroups(par::ParFile, cnames::Vector{Vector{String}}, rowrange::UnitR
         cnamesrg = colnames(rowgrp)
         found = length(intersect(cnames, cnamesrg))
         endrow = beginrow + rowgrp.num_rows - 1
-        (found == L) && (length(intersect(beginrow:endrow)) > 0) && push!(R, rowgrp)
+        (found == L) && (length(beginrow:endrow) > 0) && push!(R, rowgrp)
         beginrow = endrow + 1
     end
     R
 end
 
-columns(par::ParFile, rowgroupidx::Integer) = columns(par, rowgroups(par)[rowgroupidx])
+columns(par::ParFile, rowgroupidx) = columns(par, rowgroups(par)[rowgroupidx])
 columns(par::ParFile, rowgroup::RowGroup) = rowgroup.columns
 columns(par::ParFile, rowgroup::RowGroup, colname::Vector{String}) = columns(par, rowgroup, [colname])
 function columns(par::ParFile, rowgroup::RowGroup, cnames::Vector{Vector{String}})
@@ -166,8 +166,8 @@ function _pagevec(par::ParFile, col::ColumnChunk)
     end
     pagevec
 end
-pages(par::ParFile, rowgroupidx::Integer, colidx::Integer) = pages(par, columns(par, rowgroupidx), colidx)
-pages(par::ParFile, cols::Vector{ColumnChunk}, colidx::Integer) = pages(par, cols[colidx])
+pages(par::ParFile, rowgroupidx, colidx) = pages(par, columns(par, rowgroupidx), colidx)
+pages(par::ParFile, cols::Vector{ColumnChunk}, colidx) = pages(par, cols[colidx])
 pages(par::ParFile, col::ColumnChunk) = cacheget(par.page_cache, col, col->_pagevec(par,col))
 
 function bytes(page::Page, uncompressed::Bool=true)
@@ -195,8 +195,8 @@ end
 
 map_dict_vals(valdict::Vector{T1}, vals::Vector{T2}) where {T1, T2} = isempty(valdict) ? vals : [valdict[v+1] for v in vals]
 
-values(par::ParFile, rowgroupidx::Integer, colidx::Integer) = values(par, columns(par, rowgroupidx), colidx)
-values(par::ParFile, cols::Vector{ColumnChunk}, colidx::Integer) = values(par, cols[colidx])
+values(par::ParFile, rowgroupidx, colidx) = values(par, columns(par, rowgroupidx), colidx)
+values(par::ParFile, cols::Vector{ColumnChunk}, colidx) = values(par, cols[colidx])
 function values(par::ParFile, col::ColumnChunk)
     ctype = coltype(col)
     pgs = pages(par, col)
@@ -232,8 +232,8 @@ function values(par::ParFile, col::ColumnChunk)
     vals, defn_levels, repn_levels
 end
 
-function read_levels(io::IO, max_val::Integer, enc::Int32, num_values::Integer)
-    bw = bitwidth(max_val)
+function read_levels(io::IO, max_val::Int, enc::Int32, num_values::Int32)
+    bw = UInt8(bitwidth(max_val))
     (bw == 0) && (return Int[])
     @debug("reading levels. enc:$enc ($(Thrift.enumstr(Encoding,enc))), max_val:$max_val, num_values:$num_values")
 
@@ -249,7 +249,7 @@ function read_levels(io::IO, max_val::Integer, enc::Int32, num_values::Integer)
     end
 end
 
-function read_values(io::IO, enc::Int32, typ::Int32, num_values::Integer)
+function read_values(io::IO, enc::Int32, typ::Int32, num_values::Int32)
     @debug("reading values. enc:$enc ($(Thrift.enumstr(Encoding,enc))), num_values:$num_values")
 
     if enc == Encoding.PLAIN
@@ -280,7 +280,7 @@ function values(par::ParFile, page::Page)
     end
 end
 
-function read_levels_and_values(io::IO, encs::Tuple, ctype::Int32, num_values::Integer, par::ParFile, page::Page)
+function read_levels_and_values(io::IO, encs::Tuple, ctype::Int32, num_values::Int32, par::ParFile, page::Page)
     cname = colname(page.colchunk)
     enc, defn_enc, rep_enc = encs
 
@@ -298,7 +298,7 @@ function read_levels_and_values(io::IO, encs::Tuple, ctype::Int32, num_values::I
     # where defn_levels's elements == 1 are present and only
     # sum(defn_levels) values can be read.
     # because defn_levels == 0 are where the missing vlaues are
-    nmissing = sum(==(0), defn_levels)
+    nmissing = Int32(sum(==(0), defn_levels))
     vals = read_values(io, enc, ctype, num_values - nmissing)
 
     vals, defn_levels, repn_levels

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -67,6 +67,20 @@ function path_in_schema(sch::Schema, schelem::SchemaElement)
     error("schema element not found in schema")
 end
 
+function logical_converter(sch::Schema, schname::T) where {T <: AbstractVector{String}}
+    elem = sch.name_lookup[schname]
+
+    if schname in keys(sch.map_logical_types)
+        _logical_type, converter = sch.map_logical_types[schname]
+        return converter
+    elseif isfilled(elem, :_type) && (elem._type in keys(sch.map_logical_types))
+        _logical_type, converter = sch.map_logical_types[elem._type]
+        return converter
+    else
+        return identity
+    end
+end
+
 function logical_convert(sch::Schema, schname::T, val) where {T <: AbstractVector{String}}
     elem = sch.name_lookup[schname]
 

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -41,23 +41,23 @@ mutable struct Schema
     end
 end
 
-leafname(schname::Vector{String}) = [schname[end]]
+leafname(schname::T) where {T <: AbstractVector{String}} = [schname[end]]
 
-parentname(schname::Vector{String}) = istoplevel(schname) ? schname : schname[1:(end-1)]
+parentname(schname::T) where {T <: AbstractVector{String}} = istoplevel(schname) ? schname : schname[1:(end-1)]
 
 istoplevel(schname::Vector) = !(length(schname) > 1)
 
-elem(sch::Schema, schname::Vector{String}) = sch.name_lookup[schname]
+elem(sch::Schema, schname::T) where {T <: AbstractVector{String}} = sch.name_lookup[schname]
 
 isrepetitiontype(schelem::SchemaElement, repetition_type) = Thrift.isfilled(schelem, :repetition_type) && (schelem.repetition_type == repetition_type)
 
-isrequired(sch::Schema, schname::Vector{String}) = isrequired(elem(sch, schname))
+isrequired(sch::Schema, schname::T) where {T <: AbstractVector{String}} = isrequired(elem(sch, schname))
 isrequired(schelem::SchemaElement) = isrepetitiontype(schelem, FieldRepetitionType.REQUIRED)
 
-isoptional(sch::Schema, schname::Vector{String}) = isoptional(elem(sch, schname))
+isoptional(sch::Schema, schname::T) where {T <: AbstractVector{String}} = isoptional(elem(sch, schname))
 isoptional(schelem::SchemaElement) = isrepetitiontype(schelem, FieldRepetitionType.OPTIONAL)
 
-isrepeated(sch::Schema, schname::Vector{String}) = isrepeated(elem(sch, schname))
+isrepeated(sch::Schema, schname::T) where {T <: AbstractVector{String}} = isrepeated(elem(sch, schname))
 isrepeated(schelem::SchemaElement) = isrepetitiontype(schelem, FieldRepetitionType.REPEATED)
 
 function path_in_schema(sch::Schema, schelem::SchemaElement)
@@ -67,7 +67,7 @@ function path_in_schema(sch::Schema, schelem::SchemaElement)
     error("schema element not found in schema")
 end
 
-function logical_convert(sch::Schema, schname::Vector{String}, val)
+function logical_convert(sch::Schema, schname::T, val) where {T <: AbstractVector{String}}
     elem = sch.name_lookup[schname]
 
     if schname in keys(sch.map_logical_types)
@@ -81,7 +81,7 @@ function logical_convert(sch::Schema, schname::Vector{String}, val)
     end
 end
 
-elemtype(sch::Schema, schname::Vector{String}) = get!(sch.type_lookup, schname) do
+elemtype(sch::Schema, schname::T) where {T <: AbstractVector{String}} = get!(sch.type_lookup, schname) do
     elem = sch.name_lookup[schname]
 
     if schname in keys(sch.map_logical_types)
@@ -111,7 +111,7 @@ function elemtype(schelem::SchemaElement)
     jtype
 end
 
-ntelemtype(sch::Schema, schname::Vector{String}) = get!(sch.nttype_lookup, schname) do
+ntelemtype(sch::Schema, schname::T) where {T <: AbstractVector{String}} = get!(sch.nttype_lookup, schname) do
     ntelemtype(sch, sch.name_lookup[schname])
 end
 function ntelemtype(sch::Schema, schelem::SchemaElement)
@@ -130,12 +130,12 @@ bit_or_byte_length(schelem::SchemaElement) = Thrift.isfilled(schelem, :type_leng
 
 num_children(schelem::SchemaElement) = Thrift.isfilled(schelem, :num_children) ? schelem.num_children : 0
 
-function max_repetition_level(sch::Schema, schname::Vector{String})
+function max_repetition_level(sch::Schema, schname::T) where {T <: AbstractVector{String}}
     lev = isrepeated(sch, schname) ? 1 : 0
     istoplevel(schname) ? lev : (lev + max_repetition_level(sch, parentname(schname)))
 end 
 
-function max_definition_level(sch::Schema, schname::Vector{String})
+function max_definition_level(sch::Schema, schname::T) where {T <: AbstractVector{String}}
     lev = isrequired(sch, schname) ? 0 : 1
     istoplevel(schname) ? lev : (lev + max_definition_level(sch, parentname(schname)))
 end 

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -48,6 +48,10 @@ parentname(schname::T) where {T <: AbstractVector{String}} = istoplevel(schname)
 istoplevel(schname::Vector) = !(length(schname) > 1)
 
 elem(sch::Schema, schname::T) where {T <: AbstractVector{String}} = sch.name_lookup[schname]
+function elemindex(sch::Schema, schname::T) where {T <: AbstractVector{String}}
+    schema_element = elem(sch, schname)
+    findfirst(x->x===schema_element, sch.schema)
+end
 
 isrepetitiontype(schelem::SchemaElement, repetition_type) = Thrift.isfilled(schelem, :repetition_type) && (schelem.repetition_type == repetition_type)
 

--- a/test/test_codec.jl
+++ b/test/test_codec.jl
@@ -5,7 +5,7 @@ function test_codec()
     println("testing reading bitpacked run (old scheme)...")
     let data = UInt8[0x05, 0x39, 0x77]
         io = PipeBuffer(data)
-        decoded = Parquet.read_bitpacked_run_old(io, 8, UInt8(3))
+        decoded = Parquet.read_bitpacked_run_old(io, Int32(8), Val{UInt8(3)}())
         @test decoded == Int32[0:7;]
     end
     println("passed.")
@@ -13,11 +13,7 @@ function test_codec()
     println("testing reading bitpacked run...")
     let data = UInt8[0x88, 0xc6, 0xfa]
         io = PipeBuffer(data)
-        bits = UInt8(3)
-        byt = Parquet.bit2bytewidth(bits)
-        itype = Parquet.byt2itype(byt)
-        arr = Array{itype}(undef, 8)
-        decoded = Parquet.read_bitpacked_run(io, 1, bits, byt, itype, arr)
+        decoded = Parquet.read_bitpacked_run(io, 8, Val{UInt8(3)}())
         @test decoded == Int32[0:7;]
     end
     println("passed.")

--- a/test/test_codec.jl
+++ b/test/test_codec.jl
@@ -5,7 +5,7 @@ function test_codec()
     println("testing reading bitpacked run (old scheme)...")
     let data = UInt8[0x05, 0x39, 0x77]
         io = PipeBuffer(data)
-        decoded = Parquet.read_bitpacked_run_old(io, 8, 3)
+        decoded = Parquet.read_bitpacked_run_old(io, 8, UInt8(3))
         @test decoded == Int32[0:7;]
     end
     println("passed.")
@@ -13,7 +13,11 @@ function test_codec()
     println("testing reading bitpacked run...")
     let data = UInt8[0x88, 0xc6, 0xfa]
         io = PipeBuffer(data)
-        decoded = Parquet.read_bitpacked_run(io, 1, 3)
+        bits = UInt8(3)
+        byt = Parquet.bit2bytewidth(bits)
+        itype = Parquet.byt2itype(byt)
+        arr = Array{itype}(undef, 8)
+        decoded = Parquet.read_bitpacked_run(io, 1, bits, byt, itype, arr)
         @test decoded == Int32[0:7;]
     end
     println("passed.")

--- a/test/test_decode.jl
+++ b/test/test_decode.jl
@@ -17,25 +17,6 @@ function test_decode(file)
         for cc in ccs
             pgs = pages(p, cc)
             println("\t\treading column chunk with $(length(pgs)) pages, $(colname(cc))")
-
-            for pg in pgs
-                bpg = bytes(pg)
-                println("\t\t\tread page with $(length(bpg)) bytes")
-                if (pg.hdr._type == Parquet.PageType.DATA_PAGE) || (pg.hdr._type == Parquet.PageType.DATA_PAGE_V2)
-                    #println("\t\t\treading data page")
-                    vals, defn_levels, repn_levels = values(p, pg)
-                    println("\t\t\tread data page, $(length(defn_levels)) defn_levels, $(length(repn_levels)) repn_levels, $(length(vals)) values")
-                elseif pg.hdr._type == Parquet.PageType.DICTIONARY_PAGE
-                    #println("\t\t\treading dictionary page")
-                    vals = values(p, pg)[1]
-                    println("\t\t\tread dictionary page, $(length(vals)) values")
-                elseif pg.hdr._type == Parquet.PageType.INDEX_PAGE
-                    println("\t\t\tnot reading index page yet")
-                else
-                    error("unknown page type $(pg.hdr._type)")
-                end
-            end
-
             println("\t\tre-reading column chunk for values. total $(length(pgs)) pages")
             vals, defn_levels, repn_levels = values(p, cc)
             println("\t\t\tread $(length(vals)) values, $(length(defn_levels)) defn levels, $(length(repn_levels)) repn levels")


### PR DESCRIPTION
- performance improvements
    - type stability fixes
    - reduce allocations
- fix condition for missing column values when row can not be located in a column chunk
- `ColCursor` is now more usable as a standalone iterator over a single column

Some stats:

This is the parquet file used for testing:

```julia
julia> using Parquet

julia> par = ParFile("dsd50p.parquet");

julia> rc = RecordCursor(par);

julia> nrows(par)
28998

julia> ncols(par)
169
```

These are the timings I see:

```
julia> @time records = collect(rc); # warmup
  5.925167 seconds (26.19 M allocations: 1.060 GiB, 3.83% gc time)

julia> @time records = collect(rc);
  2.134342 seconds (22.89 M allocations: 925.233 MiB, 5.29% gc time)

julia> @time records = collect(RecordCursor(ParFile("dsd50p.parquet")));
  2.325603 seconds (23.18 M allocations: 1.058 GiB, 8.01% gc time)
```

Fetching columns directly is much faster:

```
julia> @time colvals = [collect(cc) for cc in rc.colcursors];
  0.414488 seconds (682.23 k allocations: 177.646 MiB, 6.45% gc time)
```

With some more changes full record fetch should be as fast, but that can be done as a separate PR.

This is what I see with pandas and fastparquet:

```
>>> import fastparquet
>>> import pandas as pd
>>> import time
>>> def timed_read(filename):
...     start_time = time.time()
...     par = pd.read_parquet(filename, engine='fastparquet')
...     elapsed_time = time.time() - start_time
...     print("elapsed time", elapsed_time)
...     return par
... 
>>> recs = timed_read("dsd50p.parquet");
elapsed time 3.0886640548706055

>>> recs = timed_read("dsd50p.parquet");
elapsed time 0.3566405773162842
```
