### PR TITLE
fix setrow throw BoundsError

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -60,7 +60,7 @@ function Base.iterate(cursor::RowCursor, state)
 end
 
 function Base.iterate(cursor::RowCursor)
-    r = iterate(x, _start(x))
+    r = iterate(cursor, _start(cursor))
     return r
 end
 

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -38,7 +38,7 @@ function setrow(cursor::RowCursor, row::Int64)
             startrow = last(rowgroup_row_range) + 1
         end
     end
-    throw(BoundsError(par.path, row))
+    throw(BoundsError(cursor.par.path, row))
 end
 
 rowgroup_offset(cursor::RowCursor) = cursor.row - first(cursor.rgrange)


### PR DESCRIPTION
# Description

Running this code:
```
using Parquet
p = ParFile( "./test/nested/nested1.parquet"; map_logical_types=true)
Parquet.RowCursor(p, 1:2, ["id",])
```

Would produce an `UndefVarError`.

```
ERROR: LoadError: UndefVarError: par not defined
Stacktrace:
 [1] setrow(::Parquet.RowCursor, ::Int64) at /Users/ssikdar1/Parquet.jl/src/cursor.jl:41
```

Also running this snippet:
```
p = ParFile("./test/booltest/alltypes_plain.snappy.parquet"; map_logical_types=true)
rc = Parquet.RowCursor(p, 1:2, ["id",])
print(iterate(rc))
```
Would produce this error:
```
ERROR: UndefVarError: x not defined
Stacktrace:
 [1] iterate(::Parquet.RowCursor) at /Users/ssikdar1/Parquet.jl/src/cursor.jl:63
 [2] top-level scope at REPL[3]:1
```

PR updates variable names so that both errors no longer exist:

```
$ ~/julia/julia /tmp/foo.jl 
ERROR: LoadError: BoundsError: attempt to access 29-codeunit String at index [1]
Stacktrace:
 [1] setrow(::Parquet.RowCursor, ::Int64) at /Users/ssikdar1/Parquet.jl/src/cursor.jl:41
 [2] RowCursor at /Users/ssikdar1/Parquet.jl/src/cursor.jl:20 [inlined]
 [3] Parquet.RowCursor(::ParFile, ::UnitRange{Int64}, ::Array{String,1}) at /Users/ssikdar1/Parquet.jl/src/cursor.jl:18
 [4] top-level scope at /tmp/foo.jl:5
in expression starting at /tmp/foo.jl:5
```

```
julia> parfile = "./test/booltest/alltypes_plain.snappy.parquet"
julia> p = ParFile(parfile; map_logical_types=true)
julia> rc = Parquet.RowCursor(p, 1:2, ["id",])
julia> print(iterate(rc))
julia> print(iterate(rc))
(1, 2)
```

# Testing
Via command line above.