### PR TITLE
rename ParFile to Parquet.File

### DIFF
--- a/src/Parquet.jl
+++ b/src/Parquet.jl
@@ -30,7 +30,7 @@ end
 
 import Base: show, open, close, values, eltype, length
 
-export is_par_file, ParFile, show, nrows, ncols, rowgroups, columns, pages, bytes, values, colname, colnames
+export is_par_file, show, nrows, ncols, rowgroups, columns, pages, bytes, values, colname, colnames
 export schema
 export logical_timestamp, logical_string
 export RecordCursor, BatchedColumnsCursor

--- a/src/show.jl
+++ b/src/show.jl
@@ -204,7 +204,7 @@ function show(io::IO, meta::FileMetaData, indent::AbstractString="")
     hasproperty(meta, :key_value_metadata) && show(io, meta.key_value_metadata, indent)
 end
 
-function show(io::IO, par::ParFile)
+function show(io::IO, par::Parquet.File)
     println(io, "Parquet file: $(par.path)")
     meta = par.meta
     println(io, "    version: $(meta.version)")

--- a/test/test_cursors.jl
+++ b/test/test_cursors.jl
@@ -2,7 +2,7 @@ using Parquet
 using Test
 
 function test_row_cursor(file::String)
-    p = ParFile(file)
+    p = Parquet.File(file)
 
     t1 = time()
     nr = nrows(p)
@@ -25,7 +25,7 @@ function test_row_cursor(file::String)
 end
 
 function test_batchedcols_cursor(file::String)
-    p = ParFile(file)
+    p = Parquet.File(file)
 
     t1 = time()
     nr = nrows(p)

--- a/test/test_load.jl
+++ b/test/test_load.jl
@@ -3,7 +3,7 @@ using Test
 using Dates
 
 function test_load(file::String)
-    p = ParFile(file)
+    p = Parquet.File(file)
     @debug("load file", file)
     @test isa(p.meta, Parquet.FileMetaData)
 
@@ -62,7 +62,7 @@ function test_load(file::String)
 end
 
 function test_decode(file)
-    p = ParFile(file)
+    p = Parquet.File(file)
     @debug("load file", file)
     @test isa(p.meta, Parquet.FileMetaData)
 
@@ -145,7 +145,7 @@ end
 function test_load_boolean_and_ts()
     @testset "load booleans and timestamps" begin
         @debug("load booleans and timestamps")
-        p = ParFile(joinpath(@__DIR__, "booltest", "alltypes_plain.snappy.parquet"))
+        p = Parquet.File(joinpath(@__DIR__, "booltest", "alltypes_plain.snappy.parquet"))
 
         rg = rowgroups(p)
         @test length(rg) == 1
@@ -167,7 +167,7 @@ function test_load_boolean_and_ts()
         values, _state = iterate(cc)
         @test values.timestamp_col == [DateTime("2009-04-01T12:00:00"), DateTime("2009-04-01T12:01:00")]
 
-        p = ParFile(joinpath(@__DIR__, "booltest", "alltypes_plain.snappy.parquet"); map_logical_types=Dict(["date_string_col"]=>(String,logical_string)))
+        p = Parquet.File(joinpath(@__DIR__, "booltest", "alltypes_plain.snappy.parquet"); map_logical_types=Dict(["date_string_col"]=>(String,logical_string)))
         rc = RecordCursor(p; rows=1:2, colnames=colnames(p))
         values = collect(rc)
         @test [v.date_string_col for v in values] == ["04/01/09", "04/01/09"]
@@ -176,7 +176,7 @@ function test_load_boolean_and_ts()
         values, _state = iterate(cc)
         @test values.date_string_col == ["04/01/09", "04/01/09"]
 
-        p = ParFile(joinpath(@__DIR__, "booltest", "alltypes_plain.snappy.parquet"); map_logical_types=Dict(["timestamp_col"]=>(DateTime,(v)->logical_timestamp(v; offset=Dates.Second(30)))))
+        p = Parquet.File(joinpath(@__DIR__, "booltest", "alltypes_plain.snappy.parquet"); map_logical_types=Dict(["timestamp_col"]=>(DateTime,(v)->logical_timestamp(v; offset=Dates.Second(30)))))
         rc = RecordCursor(p; rows=1:2, colnames=colnames(p))
         values = collect(rc)
         @test [v.timestamp_col for v in values] == [DateTime("2009-04-01T12:00:30"), DateTime("2009-04-01T12:01:30")]
@@ -192,7 +192,7 @@ end
 function test_load_nested()
     @testset "load nested columns" begin
         @debug("load nested columns")
-        p = ParFile(joinpath(@__DIR__, "nested", "nested1.parquet"))
+        p = Parquet.File(joinpath(@__DIR__, "nested", "nested1.parquet"))
 
         @test nrows(p) == 100
         @test ncols(p) == 5
@@ -220,7 +220,7 @@ function test_load_nested()
         @test v.reduced_max_len == 64
         @test v.vocab == "12400277_a"
 
-        p = ParFile(joinpath(@__DIR__, "nested", "nested.parq"))
+        p = Parquet.File(joinpath(@__DIR__, "nested", "nested.parq"))
 
         @test nrows(p) == 10
         @test ncols(p) == 1
@@ -242,7 +242,7 @@ end
 function test_load_multiple_rowgroups()
     @testset "testing multiple rowgroups..." begin
         @debug("load multiple rowgroups")
-        p = ParFile(joinpath(@__DIR__, "rowgroups", "multiple_rowgroups.parquet"))
+        p = Parquet.File(joinpath(@__DIR__, "rowgroups", "multiple_rowgroups.parquet"))
 
         @test nrows(p) == 100
         @test ncols(p) == 12

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -30,7 +30,7 @@ function test_write()
 
     write_parquet(tmpfile, tbl)
 
-    pf = ParFile(tmpfile)
+    pf = Parquet.File(tmpfile)
 
     # the file is very small so only one rowgroup
     col_chunks = columns(pf, 1)


### PR DESCRIPTION
`Parquet.File` seems better than `ParFile`. It is also in line with the convention used elsewhere in Julia e.g. `CSV.File` or `Arrow.Table`. Fixes #99