### PR TITLE
[Tiny] Fix ColCursor length bug

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -64,7 +64,7 @@ function ColCursor(par::Parquet.File, colname::Vector{String}; rows::UnitRange=1
 end
 
 eltype(cursor::ColCursor{T}) where {T} = NamedTuple{(:value, :defn_level, :repn_level),Tuple{Union{Nothing,T},Int64,Int64}}
-length(cursor::ColCursor) = length(cursor.row.rows)
+length(cursor::ColCursor) = length(cursor.rows)
 
 function setrow(cursor::ColCursor{T}, row::Int64) where {T}
     # check if cursor is done

--- a/test/test_cursors.jl
+++ b/test/test_cursors.jl
@@ -63,7 +63,16 @@ function test_batchedcols_cursor_all_files()
     end
 end
 
+function test_col_cursor_length()
+    path = joinpath(@__DIR__, "parquet-compatibility", "parquet-testdata", "impala", "1.1.1-SNAPPY/nation.impala.parquet")
+    pq_file = Parquet.File(path)
+    col_name = pq_file |> colnames |> first
+    col_cursor = Parquet.ColCursor(pq_file, col_name)
+    @test length(col_cursor) == 25
+end
+
 @testset "cursors" begin
     test_row_cursor_all_files()
     test_batchedcols_cursor_all_files()
+    test_col_cursor_length()
 end


### PR DESCRIPTION
There is a bug in `cursor.jl`, where calling `length(colcursor)` will break with this error:
```
type Int64 has no field rows

Stacktrace:
 [1] getproperty(::Int64, ::Symbol) at ./Base.jl:33
 [2] length(::Parquet.ColCursor{String}) at ./In[39]:2
 [3] top-level scope at In[40]:1
 [4] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1091
```

`length` is defined like so: `length(cursor::ColCursor) = length(cursor.row.rows)`, which is prevents someone from running `length(colcursor)` and therefore `collect(colcursor)`.

This PR contains a fix and a unit test