### PR TITLE
correct Base.eltype overloading

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -63,7 +63,7 @@ function ColCursor(par::Parquet.File, colname::Vector{String}; rows::UnitRange=1
     cursor
 end
 
-eltype(cursor::ColCursor{T}) where {T} = NamedTuple{(:value, :defn_level, :repn_level),Tuple{Union{Nothing,T},Int64,Int64}}
+eltype(::Type{ColCursor{T}}) where {T} = NamedTuple{(:value, :defn_level, :repn_level),Tuple{Union{Nothing,T},Int64,Int64}}
 length(cursor::ColCursor) = length(cursor.rows)
 
 function setrow(cursor::ColCursor{T}, row::Int64) where {T}
@@ -259,7 +259,7 @@ function BatchedColumnsCursor(par::Parquet.File;
     BatchedColumnsCursor{rectype}(par, colnames(par), colcursors, Array{Tuple{Int64,Int64}}(undef, length(colcursors)), colbuffs, 1, rows, first(rows), batchsize, nbatches, reusebuffer, (VERSION < v"1.3") ? false : use_threads)
 end
 
-eltype(cursor::BatchedColumnsCursor{T}) where {T} = T
+eltype(::Type{BatchedColumnsCursor{T}}) where {T} = T
 length(cursor::BatchedColumnsCursor) = cursor.nbatches
 
 function colcursor_advance(colcursor::ColCursor, rows_by::Int64, vals_by::Int64=rows_by)
@@ -380,7 +380,7 @@ function RecordCursor(par::Parquet.File; rows::UnitRange=1:nrows(par), colnames:
     RecordCursor{rectype}(par, colnames, colcursors, Array{Tuple{Int64,Int64}}(undef, length(colcursors)), rows, first(rows))
 end
 
-eltype(cursor::RecordCursor{T}) where {T} = T
+eltype(::Type{RecordCursor{T}}) where {T} = T
 length(cursor::RecordCursor) = length(cursor.rows)
 
 function Base.iterate(cursor::RecordCursor{T}, row) where {T}

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -154,7 +154,7 @@ mutable struct ColumnChunkPages
         new(par, col, startpos, endpos)
     end
 end
-eltype(ccp::ColumnChunkPages) = Page
+eltype(::Type{ColumnChunkPages}) = Page
 Base.iterate(ccp::ColumnChunkPages) = iterate(ccp, ccp.startpos)
 function Base.iterate(ccp::ColumnChunkPages, startpos::Int64)
     if startpos >= ccp.endpos
@@ -229,7 +229,7 @@ function ColumnChunkPageValues(par::Parquet.File, col::ColumnChunk, ::Type{T}, c
     ColumnChunkPageValues{T}(ccp, max_repn, max_defn, has_repn_levels, has_defn_levels, repn_out, defn_out, valdict_out, vals_out, converter_fn)
 end
 
-function eltype(ccpv::ColumnChunkPageValues{T}) where {T}
+function eltype(::Type{ColumnChunkPageValues{T}}) where {T}
    NamedTuple{(:value,:repn_level,:defn_level),Tuple{OutputState{T},OutputState{Int32},OutputState{Int32}}}
 end
 


### PR DESCRIPTION
Override `Base.eltype(::Type{T})` instead of `Base.eltype(::T)` (which invokes the former).

fixes #107