### PR TITLE
Small performance gain for read_parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ tbl = read_parquet(path_to_parquet_file)
 
 # example for how to convert to DataFrame
 using DataFrames
-df = DataFrame(tbl, copycols=true)
+df = DataFrame(tbl, copycols=false)
 ```
 
 ### Lower Level Reader

--- a/src/simple_reader.jl
+++ b/src/simple_reader.jl
@@ -1,3 +1,5 @@
+using Base.Threads
+
 """
     read_parquet(path)
 
@@ -21,7 +23,7 @@ function read_parquet(path)
 
     column_names = keys(chunks[1])
 
-    for key in column_names
+    @threads for key in column_names
         # combine all chunks' key into one column
         one_column = reduce(vcat, chunk[key] for chunk in chunks)
         result_dict[key] = one_column


### PR DESCRIPTION
Two things that speed up reading a parquet file into a dataframe are

1. Setting `copycols` to `false` in the DataFrame constructor
1. Performing `vcat` for each column on a separate thread.

We're still much slower than the pandas version - `pd.read_parquet(...)` but this should get us a step closer :)