### PR TITLE
`read_parquet` improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,28 @@
 
 You can load a [parquet file](https://en.wikipedia.org/wiki/Apache_Parquet) by using the `read_parquet` function.
 
-```
-# `tbl` is a Tables.jl compatible table
-tbl = read_parquet(path_to_parquet_file)
+`read_parquet(path; kwargs...)` returns a `Parquet.Table` instance, which is the table contained in the parquet file in an Tables.jl compatible format.
 
-# example for how to convert to DataFrame
-using DataFrames
-df = DataFrame(tbl, copycols=true)
+Options:
+- `rows`: the row range to iterate through, all rows by default.
+- `batchsize`: maximum number of rows to read in each batch (default: row count of first row group), useful to read file as partitions using `Tables.paritions`.
+- `use_threads`: whether to use threads while reading the file; applicable only for Julia v1.3 and later and switched on by default if julia processes is started with multiple threads.
+
+The returned object is a Tables.jl compatible Table and can be converted to other forms, e.g. a `DataFrames.DataFrame` via
+
+```julia
+using Parquet, DataFrames
+df = DataFrame(read_parquet(path))
+```
+
+Partitions in a parquet file can also be iterated over using an iterator returned by the `Tables.partitions(::Parquet.Table)` method.
+
+```julia
+using Parquet, DataFrames
+for partition in Tables.partitions(read_parquet(path))
+    df = DataFrame(partition)
+    ...
+end
 ```
 
 ### Lower Level Reader

--- a/src/Parquet.jl
+++ b/src/Parquet.jl
@@ -44,8 +44,8 @@ include("codec.jl")
 include("schema.jl")
 include("reader.jl")
 include("cursor.jl")
-include("show.jl")
 include("writer.jl")
 include("simple_reader.jl")
+include("show.jl")
 
 end # module

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -194,7 +194,15 @@ end
 function max_definition_level(sch::Schema, schname::T) where {T <: AbstractVector{String}}
     lev = isrequired(sch, schname) ? 0 : 1
     istoplevel(schname) ? lev : (lev + max_definition_level(sch, parentname(schname)))
-end 
+end
+
+tables_schema(parfile) = tables_schema(schema(parfile))
+function tables_schema(sch::Schema)
+    cols = Parquet.ntcolstype(sch, sch.schema[1])
+    colnames = fieldnames(cols)
+    coltypes = eltype.(fieldtypes(cols))
+    Tables.Schema(colnames, coltypes)
+end
 
 logical_decimal_unscaled_type(precision::Int32) = (precision < 5) ? UInt16 :
     (precision < 10) ? UInt32 :

--- a/src/show.jl
+++ b/src/show.jl
@@ -212,3 +212,7 @@ function show(io::IO, par::Parquet.File)
     println(io, "    created by: $(meta.created_by)")
     println(io, "    cached: $(length(par.page_cache.refs)) column chunks")
 end
+
+function show(io::IO, table::Parquet.Table)
+    print(io, "Parquet.Table(\"$(getfield(table, :path))\")")
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -46,7 +46,7 @@ function show(io::IO, schema::SchemaElement, indent::AbstractString="", nchildre
         print(io, ") ")
     end
 
-    if hasproperty(schema, :num_children)
+    if hasproperty(schema, :num_children) && (getproperty(schema, :num_children) > 0)
         push!(nchildren, schema.num_children)
         print(io, " {")
     elseif lchildren > 0

--- a/src/simple_reader.jl
+++ b/src/simple_reader.jl
@@ -20,6 +20,11 @@ Tables.partitions(t::Table) = getfield(t, :chunks)
 
 Returns the table contained in the parquet file in an Tables.jl compatible format.
 
+Options:
+- `rows`: the row range to iterate through, all rows by default.
+- `batchsize`: maximum number of rows to read in each batch (default: row count of first row group).
+- `use_threads`: whether to use threads while reading the file; applicable only for Julia v1.3 and later and switched on by default if julia processes is started with multiple threads.
+
 One can easily convert the returned object to any Tables.jl compatible table e.g.
 DataFrames.DataFrame via
 
@@ -28,11 +33,18 @@ using DataFrames
 df = DataFrame(read_parquet(path; copycols=false))
 ```
 """
-function read_parquet(path)
+function read_parquet(path;
+    rows::Union{Nothing,UnitRange}=nothing,
+    batchsize::Union{Nothing,Signed}=nothing,
+    use_threads::Bool=(nthreads() > 1))
+
     parquetfile = Parquet.File(path);
+    kwargs = Dict{Symbol,Any}(:use_threads => use_threads, :reusebuffer => false)
+    (rows === nothing) || (kwargs[:rows] = rows)
+    (batchsize === nothing) || (kwargs[:batchsize] = batchsize)
 
     # read all the chunks
-    chunks = [chunk for chunk in BatchedColumnsCursor(parquetfile)]
+    chunks = [chunk for chunk in BatchedColumnsCursor(parquetfile; kwargs...)]
     sch = Tables.schema(chunks[1])
     N = length(sch.names)
     columns = length(chunks) == 1 ? AbstractVector[chunks[1][i] for i = 1:N] : AbstractVector[ChainedVector([chunks[j][i] for j = 1:length(chunks)]) for i = 1:N]

--- a/src/simple_reader.jl
+++ b/src/simple_reader.jl
@@ -1,22 +1,6 @@
-
-struct Table <: Tables.AbstractColumns
-    schema::Tables.Schema
-    chunks::Vector
-    lookup::Dict{Symbol, Int} # map column name => index
-    columns::Vector{AbstractVector}
-end
-
-Tables.istable(::Table) = true
-Tables.columnaccess(::Table) = true
-Tables.columns(t::Table) = Tables.CopiedColumns(t)
-Tables.schema(t::Table) = getfield(t, :schema)
-Tables.columnnames(t::Table) = getfield(t, :schema).names
-Tables.getcolumn(t::Table, nm::Symbol) = Tables.getcolumn(t, getfield(t, :lookup)[nm])
-Tables.getcolumn(t::Table, i::Int) = getfield(t, :columns)[i]
-Tables.partitions(t::Table) = getfield(t, :chunks)
-
 """
-    read_parquet(path)
+    read_parquet(path; kwargs...)
+    Parquet.Table(path; kwargs...)
 
 Returns the table contained in the parquet file in an Tables.jl compatible format.
 
@@ -33,20 +17,98 @@ using DataFrames
 df = DataFrame(read_parquet(path; copycols=false))
 ```
 """
-function read_parquet(path;
-    rows::Union{Nothing,UnitRange}=nothing,
-    batchsize::Union{Nothing,Signed}=nothing,
-    use_threads::Bool=(nthreads() > 1))
+struct Table <: Tables.AbstractColumns
+    path::String
+    ncols::Int
+    rows::Union{Nothing,UnitRange}
+    batchsize::Union{Nothing,Signed}
+    use_threads::Bool
+    parfile::Parquet.File
+    schema::Tables.Schema
+    lookup::Dict{Symbol, Int} # map column name => index
+    columns::Vector{AbstractVector}
 
-    parquetfile = Parquet.File(path);
-    kwargs = Dict{Symbol,Any}(:use_threads => use_threads, :reusebuffer => false)
-    (rows === nothing) || (kwargs[:rows] = rows)
-    (batchsize === nothing) || (kwargs[:batchsize] = batchsize)
-
-    # read all the chunks
-    chunks = [chunk for chunk in BatchedColumnsCursor(parquetfile; kwargs...)]
-    sch = Tables.schema(chunks[1])
-    N = length(sch.names)
-    columns = length(chunks) == 1 ? AbstractVector[chunks[1][i] for i = 1:N] : AbstractVector[ChainedVector([chunks[j][i] for j = 1:length(chunks)]) for i = 1:N]
-    return Table(sch, chunks, Dict{Symbol, Int}(nm => i for (i, nm) in enumerate(sch.names)), columns)
+    function Table(path;
+            rows::Union{Nothing,UnitRange}=nothing,
+            batchsize::Union{Nothing,Signed}=nothing,
+            use_threads::Bool=(nthreads() > 1))
+        parfile = Parquet.File(path)
+        sch = tables_schema(parfile)
+        ncols = length(sch.names)
+        lookup = Dict{Symbol, Int}(nm => i for (i, nm) in enumerate(sch.names))
+        new(path, ncols, rows, batchsize, use_threads, parfile, sch, lookup, AbstractVector[])
+    end
 end
+
+const read_parquet = Table
+
+struct TablePartition <: Tables.AbstractColumns
+    table::Table
+    columns::Vector{AbstractVector}
+end
+
+struct TablePartitions
+    table::Table
+    ncols::Int
+    cursor::BatchedColumnsCursor
+
+    function TablePartitions(table::Table)
+        new(table, getfield(table, :ncols), cursor(table))
+    end
+end
+length(tp::TablePartitions) = length(tp.cursor)
+function iterated_partition(partitions::TablePartitions, iterresult)
+    (iterresult === nothing) && (return nothing)
+    chunk, batchid = iterresult
+    TablePartition(partitions.table, AbstractVector[chunk[colidx] for colidx in 1:partitions.ncols]), batchid
+end
+Base.iterate(partitions::TablePartitions, batchid) = iterated_partition(partitions, iterate(partitions.cursor, batchid))
+Base.iterate(partitions::TablePartitions) = iterated_partition(partitions, iterate(partitions.cursor))
+
+function cursor(table::Table)
+    kwargs = Dict{Symbol,Any}(:use_threads => getfield(table, :use_threads), :reusebuffer => false)
+    (getfield(table, :rows) === nothing) || (kwargs[:rows] = getfield(table, :rows))
+    (getfield(table, :batchsize) === nothing) || (kwargs[:batchsize] = getfield(table, :batchsize))
+    BatchedColumnsCursor(getfield(table, :parfile); kwargs...)
+end
+
+loaded(table::Table) = !isempty(getfield(table, :columns))
+load(table::Table) = load(table, cursor(table))
+function load(table::Table, chunks::BatchedColumnsCursor)
+    chunks = [chunk for chunk in chunks]
+    ncols = getfield(table, :ncols)
+    columns = getfield(table, :columns)
+
+    empty!(columns)
+    nchunks = length(chunks)
+    if nchunks == 1
+        for colidx in 1:ncols
+            push!(columns, chunks[1][colidx])
+        end
+    else
+        for colidx in 1:ncols
+            push!(columns, ChainedVector([chunks[chunkidx][colidx] for chunkidx = 1:nchunks]))
+        end
+    end
+    nothing
+end
+
+Tables.istable(::Table) = true
+Tables.columnaccess(::Table) = true
+Tables.schema(t::Table) = getfield(t, :schema)
+Tables.columnnames(t::Table) = getfield(t, :schema).names
+Tables.columns(t::Table) = Tables.CopiedColumns(t)
+Tables.getcolumn(t::Table, nm::Symbol) = Tables.getcolumn(t, getfield(t, :lookup)[nm])
+function Tables.getcolumn(t::Table, i::Int)
+    loaded(t) || load(t)
+    getfield(t, :columns)[i]
+end
+Tables.partitions(t::Table) = TablePartitions(t)
+
+Tables.istable(::TablePartition) = true
+Tables.columnaccess(::TablePartition) = true
+Tables.schema(tp::TablePartition) = Tables.schema(getfield(tp, :table))
+Tables.columnnames(tp::TablePartition) = Tables.columnnames(getfield(tp, :table))
+Tables.columns(tp::TablePartition) = Tables.CopiedColumns(tp)
+Tables.getcolumn(tp::TablePartition, nm::Symbol) = Tables.getcolumn(tp, getfield(getfield(tp, :table), :lookup)[nm])
+Tables.getcolumn(tp::TablePartition, i::Int) = getfield(tp, :columns)[i]


### PR DESCRIPTION
- add `read_parquet` options:
    - `rows`: row range to read (all by default)
    - `batchsize`: maximum number of rows to read in each batch/partition (default: row count of first row group)
    - `use_threads`: whether to use threads while reading
- `read_parquet` is now just an alias of `Parquet.Table`
- make `Tables.partitions(Parquet.Table)` implemenation to do lazy loading of partitions.
    - returns a `Parquet.TablePartitions` instance which when iterated on gives a `Parquet.TablePartition` instance which is a `Table`
    - partitions are rowgroups as encoded in the parquet file, or as per `batchsize` specified
- fix schema show method for num_children == 0
