### PR TITLE
avoid warning when mmap mode is set

### DIFF
--- a/src/Parquet.jl
+++ b/src/Parquet.jl
@@ -23,10 +23,10 @@ end
 
 const PARQUET_JL_VERSION = v"0.7.0"
 
-const _use_mmap = true
+const _use_mmap = Ref(true)
 
 function use_mmap(b::Bool)
-    global _use_mmap = b
+    _use_mmap[] = b
 end
 
 import Base: show, open, close, values, eltype, length
@@ -44,8 +44,8 @@ include("codec.jl")
 include("schema.jl")
 include("reader.jl")
 include("cursor.jl")
-include("show.jl")
 include("writer.jl")
 include("simple_reader.jl")
+include("show.jl")
 
 end # module

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -169,12 +169,12 @@ function Base.iterate(ccp::ColumnChunkPages, startpos::Int64)
 
         page_data_pos = position(io)
         pagesz = page_size(pagehdr)
-        data = _use_mmap ? Mmap.mmap(io, Vector{UInt8}, (pagesz,), page_data_pos; grow=false, shared=false) : read!(io, Array{UInt8}(undef, pagesz))
+        data = _use_mmap[] ? Mmap.mmap(io, Vector{UInt8}, (pagesz,), page_data_pos; grow=false, shared=false) : read!(io, Array{UInt8}(undef, pagesz))
         codec = metadata(ccp.par, ccp.col).codec
 
         if (codec != CompressionCodec.UNCOMPRESSED)
             uncompressed_sz = pagehdr.uncompressed_page_size
-            #uncompressed_data = _use_mmap ? Mmap.mmap(Mmap.Anonymous(), Vector{UInt8}, (uncompressed_sz,), 0) : Array{UInt8}(undef, uncompressed_sz)
+            #uncompressed_data = _use_mmap[] ? Mmap.mmap(Mmap.Anonymous(), Vector{UInt8}, (uncompressed_sz,), 0) : Array{UInt8}(undef, uncompressed_sz)
             uncompressed_data = Array{UInt8}(undef, uncompressed_sz)
             if codec == CompressionCodec.SNAPPY
                 Snappy.snappy_uncompress(data, uncompressed_data)

--- a/test/test_load.jl
+++ b/test/test_load.jl
@@ -293,6 +293,21 @@ function test_load_at_offset()
     end
 end
 
+function test_mmap_mode()
+    @testset "memory map modes" begin
+        default_mode = Parquet._use_mmap[]
+        for mode in (true, false)
+            (mode === default_mode) && continue
+            Parquet.use_mmap(mode)
+            table = read_parquet(joinpath(@__DIR__, "rowgroups", "multiple_rowgroups.parquet"))
+            cols = Tables.columns(table)
+            @test all([length(col)==100 for col in cols])
+            @test length(cols) == 12
+        end
+        Parquet.use_mmap(default_mode)
+    end
+end
+
 @testset "load files" begin
     test_load_all_pages()
     test_decode_all_pages()
@@ -301,4 +316,5 @@ end
     test_load_multiple_rowgroups()
     test_load_file()
     test_load_at_offset()
+    test_mmap_mode()
 end


### PR DESCRIPTION
Use a `const Ref` to prevent `Parquet.use_mmap` from issuing a warning when memory mapping mode is set.