### PR TITLE
fix reading dataset without metadata file

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -69,7 +69,7 @@ function dataset_schema(path::String)
             for file in files
                 full_filename = joinpath(root, file)
                 if is_par_file(full_filename)
-                    schema = tables_schema(Parquet.File(meta_file))
+                    schema = tables_schema(Parquet.File(full_filename))
                     break
                 end
             end

--- a/test/test_load.jl
+++ b/test/test_load.jl
@@ -376,6 +376,7 @@ function test_dataset()
         @test startswith(String(take!(iob)), "Parquet.Dataset(")
         close(dataset)
 
+        # load dataset with a filter
         dataset = read_parquet(dataset_path; filter=(path)->occursin("bool=false", lowercase(path)))
         @test Tables.istable(dataset)
         @test Tables.columnaccess(dataset)
@@ -390,6 +391,17 @@ function test_dataset()
         end
         @test length(partitions) == 1
         close(dataset)
+
+        # load dataset without metadata file
+        mktempdir() do path
+            new_dataset = joinpath(path, "dataset")
+            cp(dataset_path, new_dataset)
+            metafile = joinpath(new_dataset, "_common_metadata")
+            rm(metafile)
+            dataset = read_parquet(new_dataset)
+            @test Tables.istable(dataset)
+            @test Tables.columnaccess(dataset)
+        end
     end
 end
 


### PR DESCRIPTION
Fixes a bug that resulted in being unable to read datasets without a metadata file. The metadata is now picked up from any of the partitions of the dataset (as mentioned in #138).

Also added tests for this condition.

fixes #139 