### PR TITLE
Update writer.jl usage of Tables.Columns

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -458,7 +458,7 @@ compression_code    -   Default "SNAPPY". The compression codec. The supported
                         values are "UNCOMPRESSED", "SNAPPY", "ZSTD", "GZIP"
 """
 function write_parquet(io::IO, x; compression_codec = "SNAPPY")
-    tbl = Tables.columns(x)
+    tbl = Tables.Columns(x)
 
     # check that all types are supported
     sch = Tables.schema(tbl)
@@ -505,7 +505,7 @@ function write_parquet(io::IO, x; compression_codec = "SNAPPY")
     colnames = String.(Tables.columnnames(tbl))
     _write_parquet(
         io,
-        Tables.Columns(tbl),
+        tbl,
         Tables.columnnames(tbl),
         recommended_chunks;
         encoding    =   Dict(col => encoding for col in colnames),


### PR DESCRIPTION
From the change in https://github.com/JuliaData/Tables.jl/pull/255, we're considering the fact that Tables.Columns didn't call Tables.columns a bug, so it's being changed and you don't need to call Tables.columns yourself anymore when using Tables.Columns. Luckily, I'm not aware of any table inputs where this actually makes a difference (i.e. a table where Tables.columns(x) !== x), so this shouldn't be very disruptive.